### PR TITLE
Remove mode adjustment on the watch side

### DIFF
--- a/wear/src/main/java/se/blunden/donotdisturbsync/WearMessageListenerService.java
+++ b/wear/src/main/java/se/blunden/donotdisturbsync/WearMessageListenerService.java
@@ -50,11 +50,6 @@ public class WearMessageListenerService extends WearableListenerService {
                     return;
                 }
 
-                // Wear OS's DND modes behave unexpectedly so toggle Alarms Only or Off instead
-                if (newMode != NotificationManager.INTERRUPTION_FILTER_ALL) {
-                    newMode = NotificationManager.INTERRUPTION_FILTER_ALARMS;
-                }
-
                 Log.d(TAG, "Attempting to set adjusted DND mode " + newMode);
                 mNotificationManager.setInterruptionFilter(newMode);
             } else {


### PR DESCRIPTION
this caused DND Sync to unexpectedly also change modes on the phone side, since changed mode on the watch is then synced back to the phone:

1. Enable DND with time limit on the phone. This seems to default to priority mode
2. Priority is synced to the watch
3. Watch overrides priority with alarms only
4. Alarms only is synced back to the phone
5. priority with time limit is overriden by the new alarms only mode.

From what I can see on my Galaxy Watch 4, priority mode seems to also work fine on the watch.

This fixes #2 